### PR TITLE
Defer the wsp file Close() before chances to get out of the loop

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,6 +116,8 @@ func handleConnection(conn net.Conn, schemas []*StorageSchema, aggrs []*StorageA
 		// do what we want to do
 		path := config.WhisperData + "/" + strings.Replace(metric, ".", "/", -1) + ".wsp"
 		w, err := whisper.Open(path)
+		defer w.Close()
+
 		if err != nil && os.IsNotExist(err) {
 			w = createMetric([]byte(metric), path, schemas, aggrs)
 			if w == nil {
@@ -131,7 +133,6 @@ func handleConnection(conn net.Conn, schemas []*StorageSchema, aggrs []*StorageA
 		if err != nil {
 			logger.Logf("failed to update whisper file %s: %v", path, err)
 		}
-		w.Close()
 
 		Metrics.MetricsReceived.Add(1)
 	}


### PR DESCRIPTION
I was looking at why carbonwriter was being OOM killed before and in looking at the heap output I saw this. The code looks like it bypass the `w.Close()` call under a couple conditions in the loop. 

Also, I saw there could be an additional guard of `if w == nil` around the `w = createMetric([]byte(metric), path, schemas, aggrs)` call. Thoughts? 

```
adam@Planet-X -- ~:  go tool pprof -cum -tree -alloc_space http://graphite0.infra.production.lks.banno-internal.com:8080/debug/pprof/heap\?debug\=1
Fetching profile from http://graphite0.infra.production.lks.banno-internal.com:8080/debug/pprof/heap?debug=1
Saved profile in /Users/adam/pprof/pprof.graphite0.infra.production.lks.banno-internal.com:8080.alloc_objects.alloc_space.011.pb.gz
2419.72MB of 2431.43MB total (99.52%)
Dropped 42 nodes (cum <= 12.16MB)
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context
----------------------------------------------------------+-------------
         0     0%     0%  2248.41MB 92.47%                | runtime.goexit
                                         2244.21MB   100% |   main.handleConnection
----------------------------------------------------------+-------------
                                         2244.21MB   100% |   runtime.goexit
  697.57MB 28.69% 28.69%  2244.21MB 92.30%                | main.handleConnection
                                          639.05MB 41.59% |   github.com/grobian/go-whisper.Open
                                          432.04MB 28.12% |   strings.Replace
                                          285.53MB 18.58% |   bufio.(*Reader).ReadBytes
                                             105MB  6.83% |   strings.Split
                                              75MB  4.88% |   strings.TrimRight
----------------------------------------------------------+-------------
                                          639.05MB   100% |   main.handleConnection
  256.01MB 10.53% 39.22%   639.05MB 26.28%                | github.com/grobian/go-whisper.Open
                                          383.04MB   100% |   os.OpenFile
----------------------------------------------------------+-------------
                                          432.04MB   100% |   main.handleConnection
  432.04MB 17.77% 56.99%   432.04MB 17.77%                | strings.Replace
----------------------------------------------------------+-------------
                                          383.04MB   100% |   github.com/grobian/go-whisper.Open
    2.50MB   0.1% 57.09%   385.54MB 15.86%                | os.OpenFile
                                          301.04MB 78.59% |   syscall.Open
                                              82MB 21.41% |   os.NewFile
----------------------------------------------------------+-------------
```